### PR TITLE
Return info msg for `/health` endpoint (#1465)

### DIFF
--- a/crossdock/main.go
+++ b/crossdock/main.go
@@ -102,10 +102,14 @@ func (h *clientHandler) isInitialized() bool {
 	return atomic.LoadUint64(&h.initialized) != 0
 }
 
+func is2xxStatusCode(statusCode int) bool {
+	return statusCode >= 200 && statusCode <= 299
+}
+
 func httpHealthCheck(logger *zap.Logger, service, healthURL string) {
 	for i := 0; i < 240; i++ {
 		res, err := http.Get(healthURL)
-		if err == nil && res.StatusCode == 204 {
+		if err == nil && is2xxStatusCode(res.StatusCode) {
 			logger.Info("Health check successful", zap.String("service", service))
 			return
 		}

--- a/pkg/healthcheck/internal_test.go
+++ b/pkg/healthcheck/internal_test.go
@@ -15,9 +15,12 @@
 package healthcheck
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,5 +37,35 @@ func TestHttpCall(t *testing.T) {
 
 	resp, err := http.Get(server.URL + "/")
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	hr := parseHealthCheckResponse(t, resp)
+	assert.Equal(t, "Server available", hr.StatusMsg)
+	// de-serialized timestamp loses monotonic clock value, so assert.Equals() doesn't work.
+	// https://github.com/stretchr/testify/issues/502
+	if want, have := hc.getState().upSince, hr.UpSince; !assert.True(t, want.Equal(have)) {
+		t.Logf("want='%v', have='%v'", want, have)
+	}
+	assert.NotZero(t, hr.Uptime)
+	t.Logf("uptime=%v", hr.Uptime)
+
+	time.Sleep(time.Millisecond)
+	hc.Set(Unavailable)
+
+	resp, err = http.Get(server.URL + "/")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	hrNew := parseHealthCheckResponse(t, resp)
+	assert.Zero(t, hrNew.Uptime)
+	assert.Zero(t, hrNew.UpSince)
+}
+
+func parseHealthCheckResponse(t *testing.T, resp *http.Response) healthCheckResponse {
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var hr healthCheckResponse
+	err = json.Unmarshal(body, &hr)
+	require.NoError(t, err)
+	return hr
 }


### PR DESCRIPTION
* Return info msg for `/health` endpoint

Return 200 OK for status `ready` and `upTimeStats`

Resolves #1450

Signed-off-by: stefan vassilev <stefanvassilev1@gmail.com>

* Address PR comments

Signed-off-by: stefan vassilev <stefanvassilev1@gmail.com>

* Fix failing test

Signed-off-by: stefan vassilev <stefanvassilev1@gmail.com>

* Address PR comments

Signed-off-by: stefan vassilev <stefanvassilev1@gmail.com>

* Retrigger tests

Signed-off-by: stefan vassilev <stefanvassilev1@gmail.com>

* Retrigger tests

Signed-off-by: stefan vassilev <stefanvassilev1@gmail.com>

* Make thread-safe

Signed-off-by: Yuri Shkuro <ys@uber.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- 

## Short description of the changes
- 
